### PR TITLE
Fix eager loading when there are multiple view roots

### DIFF
--- a/lib/fortitude/rails/railtie.rb
+++ b/lib/fortitude/rails/railtie.rb
@@ -233,7 +233,7 @@ module Fortitude
                       ((entry == filename) || (entry =~ regexp1 && entry =~ regexp2)) && File.file?(File.join(directory, entry))
                     end
 
-                    return nil if applicable_entries.length == 0
+                    next if applicable_entries.empty?
 
                     # Prefer those without an underscore
                     without_underscore = applicable_entries.select { |e| e !~ /^_/ }


### PR DESCRIPTION
This was returning early if it found a dir that could contain the file 
even if it didn’t contain the file we were looking for. This changes it
to look in all the view roots before giving up.
