### PR TITLE
Update Template Handler Call for Rails 6

### DIFF
--- a/lib/fortitude/rails/template_handler.rb
+++ b/lib/fortitude/rails/template_handler.rb
@@ -51,10 +51,10 @@ module Fortitude
 
     module RegisterTemplateHandlerOverrides
       def register_template_handler_uniwith_fortitude(original_method, *args, &block)
-        original_method.call(*args, &block)
+        original_method.call(*args, &block, nil)
 
         unless args[0] == :rb && args[1].instance_of?(::Fortitude::Rails::TemplateHandler)
-          original_method.call(:rb, ::Fortitude::Rails::TemplateHandler.new)
+          original_method.call(:rb, ::Fortitude::Rails::TemplateHandler.new, nil)
         end
       end
     end

--- a/lib/fortitude/rails/template_handler.rb
+++ b/lib/fortitude/rails/template_handler.rb
@@ -3,7 +3,7 @@ require 'fortitude/rails/renderer'
 module Fortitude
   module Rails
     class TemplateHandler
-      def call(template, &block)
+      def call(template, source = nil, &block)
         # This is a little funny. Under almost every single circumstance, we can, at template-compile time, deduce
         # what class is inside the template file, and simply call Fortitude::Rails::Renderer.render with that class.
         #
@@ -44,7 +44,7 @@ module Fortitude
 
       class << self
         def register!
-          ::ActionView::Template.register_template_handler(:rb, ::Fortitude::Rails::TemplateHandler.new, nil)
+          ::ActionView::Template.register_template_handler(:rb, ::Fortitude::Rails::TemplateHandler.new)
         end
       end
     end

--- a/lib/fortitude/rails/template_handler.rb
+++ b/lib/fortitude/rails/template_handler.rb
@@ -44,17 +44,17 @@ module Fortitude
 
       class << self
         def register!
-          ::ActionView::Template.register_template_handler(:rb, ::Fortitude::Rails::TemplateHandler.new)
+          ::ActionView::Template.register_template_handler(:rb, ::Fortitude::Rails::TemplateHandler.new, nil)
         end
       end
     end
 
     module RegisterTemplateHandlerOverrides
       def register_template_handler_uniwith_fortitude(original_method, *args, &block)
-        original_method.call(*args, &block, nil)
+        original_method.call(*args, &block)
 
         unless args[0] == :rb && args[1].instance_of?(::Fortitude::Rails::TemplateHandler)
-          original_method.call(:rb, ::Fortitude::Rails::TemplateHandler.new, nil)
+          original_method.call(:rb, ::Fortitude::Rails::TemplateHandler.new)
         end
       end
     end


### PR DESCRIPTION
This fixes a deprecation warning in Rails 6 by adding the `source` parameter to the template handler `call` method (with a default of `nil`)

Tested locally (via `ent-search`), and it _appears_ to work correctly, and the deprecation warning is gone.