### PR TITLE
Fix kwargs error to better support Ruby 3.0+

### DIFF
--- a/lib/fortitude/version.rb
+++ b/lib/fortitude/version.rb
@@ -1,3 +1,3 @@
 module Fortitude
-  VERSION = "0.9.6.swiftype03"
+  VERSION = "0.9.6.swiftype04"
 end

--- a/lib/fortitude/widget/helpers.rb
+++ b/lib/fortitude/widget/helpers.rb
@@ -48,9 +48,9 @@ module Fortitude
             end
 
             text = <<-EOS
-    def #{name}(*args, &block)
+    def #{name}(*args, **kwargs, &block)
       #{block_transform}
-      #{prefix}(@_fortitude_rendering_context.helpers_object#{call_part}*args, &effective_block))#{suffix}
+      #{prefix}(@_fortitude_rendering_context.helpers_object#{call_part}*args, **kwargs, &effective_block))#{suffix}
     end
 EOS
 


### PR DESCRIPTION
This PR is not to make the whole engine compatible with Ruby 3.0+, but to fix the component used by `ent-search` to make `ent-search` compatible with Ruby 3.0+