### PR TITLE
correct operator precedence: '!!' vs '=~'

### DIFF
--- a/lib/fortitude/rails/renderer.rb
+++ b/lib/fortitude/rails/renderer.rb
@@ -20,7 +20,7 @@ module Fortitude
           widget_class = ::Fortitude::Widget.widget_class_from_file(template_identifier,
             :root_dirs => expanded_view_paths, :valid_base_classes => valid_base_classes)
 
-          is_partial = !! File.basename(template_identifier) =~ /^_/
+          is_partial = !!(File.basename(template_identifier) =~ /^_/)
 
           render(widget_class, template_handler, local_assigns, is_partial, &block)
         end

--- a/lib/fortitude/rails/template_handler.rb
+++ b/lib/fortitude/rails/template_handler.rb
@@ -20,7 +20,7 @@ module Fortitude
         # path if absolutely necessary.
         expanded_view_paths = ::Rails.application.paths['app/views'].map { |path| File.expand_path(path.to_s, ::Rails.root.to_s) }
         valid_base_classes = [ ::Fortitude::Widget, ::Fortitude::Erector.erector_widget_base_class_if_available ].compact
-        is_partial = !! File.basename(template.identifier) =~ /^_/
+        is_partial = !!(File.basename(template.identifier) =~ /^_/)
 
         widget_class = nil
 

--- a/lib/fortitude/version.rb
+++ b/lib/fortitude/version.rb
@@ -1,3 +1,3 @@
 module Fortitude
-  VERSION = "0.9.6.swiftype04"
+  VERSION = "0.9.6.swiftype05"
 end


### PR DESCRIPTION
```sh
irb(main):001:0> File.basename("foo/_bar") =~ /^_/
=> 0
irb(main):002:0> !! (File.basename("foo/_bar") =~ /^_/) # patched: correct (true)
=> true
irb(main):003:0> !! File.basename("foo/_bar") =~ /^_/   # original: incorrect
=> nil

irb(main):004:0> File.basename("foo/bar") =~ /^_/
=> nil
irb(main):006:0> !! (File.basename("foo/bar") =~ /^_/) # patched: correct (false)
=> false
irb(main):005:0> !! File.basename("foo/bar") =~ /^_/   # original: correct-ish (nil)
=> nil
```